### PR TITLE
remove react logos from manifest file

### DIFF
--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
There was an error in manifest file, because react logos were deleted from the directory.